### PR TITLE
fix: Sync images to worker registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   docker-image-build:
-    runs-on: [self-hosted, ARM64, Linux]
+    runs-on: [self-hosted, ARM64, Linux, 1st]
     steps:
     - uses: actions/checkout@v7
     - name: Set up Docker Build Environment
@@ -23,5 +23,9 @@ jobs:
         no-cache: true
     - name: Push image to local registry
       run: docker push localhost:5000/hyuabot-database-initializer:latest
+    - name: Sync image to worker registry
+      uses: hyuabot-developers/hyuabot-infrastructure/.github/actions/sync-local-registry@a091ea37f391ae60eb7828325782a397cc7cae9c
+      with:
+        image: localhost:5000/hyuabot-database-initializer:latest
     - name: Remove image from local registry
       run: docker rmi localhost:5000/hyuabot-database-initializer:latest


### PR DESCRIPTION
## Summary

- Synchronize each newly pushed image from the first node registry to the worker node registry.
- Pin the shared synchronization action to an immutable infrastructure commit.
- Pin the deployment job to the first self-hosted runner, which owns the source registry.

## Root Cause

The two K3s nodes resolve `localhost:5000` to separate Docker registries, so pushing an image on the first node does not make it available to workloads scheduled on the worker.

## Impact

Deployment now completes only after the worker registry contains the same image config and layers. The registry remains bound locally on each server and is not exposed publicly.

## Validation

- Parsed the workflow YAML successfully.
- Passed `git diff --check`.
- Verified the pinned shared action in a production backend deployment.